### PR TITLE
Relax phpstan to caret version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "phpstan/phpstan": "^0.10 | v0.11",
+        "phpstan/phpstan": "^0.10 | ^0.11",
         "thecodingmachine/safe": "^0.1.11"
     },
     "require-dev": {


### PR DESCRIPTION
Hi there,
phpstan has new bugfix version which is blocked by locally required version.