### PR TITLE
Dont lock PHPStan dependency to v0.11, allow ^0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "phpstan/phpstan": "^0.10 | v0.11",
+        "phpstan/phpstan": "^0.10 | ^0.11",
         "thecodingmachine/safe": "^0.1.11"
     },
     "require-dev": {


### PR DESCRIPTION
I get this error while requiring the package:
```
  Problem 1
    - Can only install one of: phpstan/phpstan[0.11, 0.11.1].
    - Can only install one of: phpstan/phpstan[0.11.1, 0.11].
    - Can only install one of: phpstan/phpstan[0.11, 0.11.1].
    - thecodingmachine/phpstan-safe-rule v0.1.1 requires phpstan/phpstan ^0.10 | v0.11 -> satisfiable by phpstan/phpstan[0.11].
    - Installation request for thecodingmachine/phpstan-safe-rule ^0.1.1 -> satisfiable by thecodingmachine/phpstan-safe-rule[v0.1.1].
    - Installation request for phpstan/phpstan (locked at 0.11.1, required as ^0.11) -> satisfiable by phpstan/phpstan[0.11.1].
```

I guess it's related to the locked version