### PR TITLE
Add safe8 paths to FunctionListLoader

### DIFF
--- a/src/Utils/FunctionListLoader.php
+++ b/src/Utils/FunctionListLoader.php
@@ -24,6 +24,10 @@ class FunctionListLoader
                 $functions = require __DIR__.'/../../../safe/generated/functionsList.php';
             } elseif (\file_exists(__DIR__.'/../../vendor/thecodingmachine/safe/generated/functionsList.php')) {
                 $functions = require __DIR__.'/../../vendor/thecodingmachine/safe/generated/functionsList.php';
+            } elseif (\file_exists(__DIR__.'/../../../safe8/generated/functionsList.php')) {
+                $functions = require __DIR__.'/../../../safe8/generated/functionsList.php';
+            } elseif (\file_exists(__DIR__.'/../../vendor/thecodingmachine/safe8/generated/functionsList.php')) {
+                $functions = require __DIR__.'/../../vendor/thecodingmachine/safe8/generated/functionsList.php';
             } else {
                 throw new \RuntimeException('Could not find thecodingmachine/safe\'s functionsList.php file.');
             }


### PR DESCRIPTION
When used in combination with safe8 the `functionsList.php` file can't be found, as safe8 is using a different folder.

This PR adds the safe8 paths to the Loader.