### PR TITLE
support phpstan 1.0; drop support for phpstan < 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "phpstan/phpstan": "^0.10 | ^0.11 | ^0.12 | ^1.0",
+        "phpstan/phpstan": "^1.0",
         "thecodingmachine/safe": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "phpstan/phpstan": "^0.10 | ^0.11 | ^0.12",
+        "phpstan/phpstan": "^0.10 | ^0.11 | ^0.12 | ^1.0",
         "thecodingmachine/safe": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.1-dev"
         },
         "phpstan": {
             "includes": [

--- a/tests/Rules/CallMethodRuleTest.php
+++ b/tests/Rules/CallMethodRuleTest.php
@@ -2,8 +2,11 @@
 
 namespace TheCodingMachine\Safe\PHPStan\Rules;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\FunctionCallParametersCheck;
 use PHPStan\Rules\Methods\CallMethodsRule;
+use PHPStan\Rules\NullsafeCheck;
+use PHPStan\Rules\PhpDoc\UnresolvableTypeHelper;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Testing\RuleTestCase;
@@ -14,10 +17,10 @@ class CallMethodRuleTest extends RuleTestCase
     protected function getRule(): Rule
     {
         $broker = $this->createBroker();
-        $ruleLevelHelper = new RuleLevelHelper($broker, true, true, true);
+        $ruleLevelHelper = new RuleLevelHelper($broker, true, true, true, false);
         return new CallMethodsRule(
             $broker,
-            new FunctionCallParametersCheck($ruleLevelHelper, true, true, true, true),
+            new FunctionCallParametersCheck($ruleLevelHelper, new NullsafeCheck(), new PhpVersion(PHP_VERSION_ID), new UnresolvableTypeHelper(), true, false, false, false),
             $ruleLevelHelper,
             true,
             true


### PR DESCRIPTION
[phpstan 0.x will no longer be supported](https://twitter.com/OndrejMirtes/status/1455083738564542467). prepare the rule for phpstan 1.0+


Fixes #25