### PR TITLE
Require safe ^1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.1",
         "phpstan/phpstan": "^2.0",
-        "thecodingmachine/safe": "^1.0 || ^2.0 || ^3.0",
+        "thecodingmachine/safe": "^1.2 || ^2.0 || ^3.0",
         "nikic/php-parser": "^5"
     },
     "require-dev": {


### PR DESCRIPTION

1.0 and 1.1 use `resource` as a literal type hint, which is interpreted as a class name, which results in error reports

(I'm not sure why anybody would be using safe v1.0 or v1.1, but our test suite checks with `--prefer-lowest`, and I'm not sure why that didn't catch this issue earlier)
