### PR TITLE
Consider named argument flags:JSON_THROW_ON_ERROR for json_ functions as "Safe"

### DIFF
--- a/src/Rules/UseSafeFunctionsRule.php
+++ b/src/Rules/UseSafeFunctionsRule.php
@@ -33,6 +33,19 @@ class UseSafeFunctionsRule implements Rule
         $unsafeFunctions = FunctionListLoader::getFunctionList();
 
         if (isset($unsafeFunctions[$functionName])) {
+            if ($functionName === "json_decode" || $functionName === "json_encode") {
+                foreach ($node->args as $arg) {
+                    if ($arg instanceof Node\Arg &&
+                        $arg->name instanceof Node\Identifier &&
+                        $arg->name->toLowerString() === "flags"
+                    ) {
+                        if ($this->argValueIncludeJSONTHROWONERROR($arg)) {
+                            return [];
+                        }
+                    }
+                }
+            }
+
             if ($functionName === "json_decode"
                 && $this->argValueIncludeJSONTHROWONERROR($node->getArgs()[3] ?? null)
             ) {

--- a/tests/Rules/UseSafeFunctionsRuleTest.php
+++ b/tests/Rules/UseSafeFunctionsRuleTest.php
@@ -37,11 +37,11 @@ class UseSafeFunctionsRuleTest extends RuleTestCase
 
     public function testJSONDecodeNoCatchSafe(): void
     {
-        $this->analyse([__DIR__ . '/data/safe_json_decode_for_7.3.0.php'], []);
+        $this->analyse([__DIR__ . '/data/safe_json_decode.php'], []);
     }
 
     public function testJSONEncodeNoCatchSafe(): void
     {
-        $this->analyse([__DIR__ . '/data/safe_json_encode_for_7.3.0.php'], []);
+        $this->analyse([__DIR__ . '/data/safe_json_encode.php'], []);
     }
 }

--- a/tests/Rules/data/safe_json_decode.php
+++ b/tests/Rules/data/safe_json_decode.php
@@ -1,9 +1,14 @@
 <?php
 
+// Test various combinations of flags
 json_decode("{}", true, 512, JSON_THROW_ON_ERROR);
 json_decode("{}", true, 512, JSON_INVALID_UTF8_IGNORE | JSON_THROW_ON_ERROR);
 json_decode("{}", true, 512, JSON_INVALID_UTF8_IGNORE | JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR);
 
+// Test raw integers too
 json_decode("{}", true, 512, 4194304);
 json_decode("{}", true, 512, 1048576 | 4194304);
 json_decode("{}", true, 512, 1048576 | 1 | 4194304);
+
+// Test named arguments instead of positional
+json_decode("{}", flags: JSON_THROW_ON_ERROR);

--- a/tests/Rules/data/safe_json_encode.php
+++ b/tests/Rules/data/safe_json_encode.php
@@ -3,3 +3,5 @@
 json_encode([], JSON_THROW_ON_ERROR, 512);
 json_encode([], JSON_FORCE_OBJECT | JSON_THROW_ON_ERROR, 512);
 json_encode([], JSON_FORCE_OBJECT | JSON_INVALID_UTF8_IGNORE | JSON_THROW_ON_ERROR, 512);
+
+json_encode([], flags: JSON_THROW_ON_ERROR);


### PR DESCRIPTION

Manually rebasing, adding unit tests, and fixing the tests, for #33
