### PR TITLE
Fix tests with latest dependencies

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,8 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
-        dependencies: ["highest"]
+        dependencies:
+          - "highest"
         include:
           - description: "(lowest)"
             php: "8.1"
@@ -44,7 +45,7 @@ jobs:
       - name: "Upload test coverage"
         uses: codecov/codecov-action@v5
         with:
-          files: "./coverage.xml"
+          files: coverage.xml
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/tests/Type/Php/data/preg_match_checked.php
+++ b/tests/Type/Php/data/preg_match_checked.php
@@ -8,7 +8,7 @@ $string = 'Hello World';
 
 // when the return value is checked, we should have matches,
 // unless the match-group itself is optional
-$type = "array{0: string, 1: non-empty-string, 2: 'o', 3?: 'World'}";
+$type = "array{0: non-falsy-string, 1: non-empty-string, 2: 'o', 3?: 'World'}";
 
 // @phpstan-ignore-next-line - use of unsafe is intentional
 if(\preg_match($pattern, $string, $matches)) {


### PR DESCRIPTION
I tried to continue work on https://github.com/thecodingmachine/phpstan-safe-rule/pull/32, but found that an unrelated test was failing after I ran `composer update`.