### PR TITLE
Sync `preg_match` extensions with PHPStan upstream + expose identity-check narrowing bug

### DIFF
--- a/src/Type/Php/PregMatchParameterOutTypeExtension.php
+++ b/src/Type/Php/PregMatchParameterOutTypeExtension.php
@@ -13,8 +13,10 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParameterReflection;
 use PHPStan\TrinaryLogic;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\FunctionParameterOutTypeExtension;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 use function in_array;
 
 final class PregMatchParameterOutTypeExtension implements FunctionParameterOutTypeExtension
@@ -50,7 +52,14 @@ final class PregMatchParameterOutTypeExtension implements FunctionParameterOutTy
         }
 
         if ($functionReflection->getName() === 'Safe\preg_match') {
-            return $this->regexShapeMatcher->matchExpr($patternArg->value, $flagsType, TrinaryLogic::createMaybe(), $scope);
+            $matchedType = $this->regexShapeMatcher->matchExpr($patternArg->value, $flagsType, TrinaryLogic::createYes(), $scope);
+            if ($matchedType === null) {
+                return null;
+            }
+            return TypeCombinator::union(
+                ConstantArrayTypeBuilder::createEmpty()->getArray(),
+                $matchedType,
+            );
         }
         return $this->regexShapeMatcher->matchAllExpr($patternArg->value, $flagsType, TrinaryLogic::createMaybe(), $scope);
     }

--- a/src/Type/Php/PregMatchTypeSpecifyingExtension.php
+++ b/src/Type/Php/PregMatchTypeSpecifyingExtension.php
@@ -55,10 +55,18 @@ final class PregMatchTypeSpecifyingExtension implements FunctionTypeSpecifyingEx
             $flagsType = $scope->getType($flagsArg->value);
         }
 
-        if ($functionReflection->getName() === 'Safe\preg_match') {
-            $matchedType = $this->regexShapeMatcher->matchExpr($patternArg->value, $flagsType, TrinaryLogic::createFromBoolean($context->true()), $scope);
+        if ($context->true() && $context->falsey()) {
+            $wasMatched = TrinaryLogic::createMaybe();
+        } elseif ($context->true()) {
+            $wasMatched = TrinaryLogic::createYes();
         } else {
-            $matchedType = $this->regexShapeMatcher->matchAllExpr($patternArg->value, $flagsType, TrinaryLogic::createFromBoolean($context->true()), $scope);
+            $wasMatched = TrinaryLogic::createNo();
+        }
+
+        if ($functionReflection->getName() === 'Safe\preg_match') {
+            $matchedType = $this->regexShapeMatcher->matchExpr($patternArg->value, $flagsType, $wasMatched, $scope);
+        } else {
+            $matchedType = $this->regexShapeMatcher->matchAllExpr($patternArg->value, $flagsType, $wasMatched, $scope);
         }
         if ($matchedType === null) {
             return new SpecifiedTypes();

--- a/tests/Type/Php/TypeAssertionsTest.php
+++ b/tests/Type/Php/TypeAssertionsTest.php
@@ -15,6 +15,7 @@ class TypeAssertionsTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/preg_match_checked.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/preg_replace_return.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/json_decode_return.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/preg_match_identity_check.php');
     }
 
     /**

--- a/tests/Type/Php/data/preg_match_identity_check.php
+++ b/tests/Type/Php/data/preg_match_identity_check.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace TheCodingMachine\Safe\PHPStan\Type\Php\data;
+
+use function Safe\preg_match;
+
+// PHPStan bug report: Safe\preg_match with "1 ===" identity check does NOT narrow $matches,
+// even though plain truthy if (preg_match(...)) works correctly.
+//
+// Root cause: PHPStan's TypeSpecifier.php has a hardcoded literal-name check for 'preg_match'
+// in resolveNormalizedIdentical(). This triggers specifyTypesInCondition() on the FuncCall, but
+// the FuncCall is wrapped in AlwaysRememberedExpr at that point, so FunctionTypeSpecifyingExtension
+// is never called and $matches is not narrowed.
+//
+// This affects ANY extension-based preg_match wrapper (e.g. Safe\preg_match) — not only native.
+
+$pattern = '/H(.)ll(o) (World)?/';
+$string = 'Hello World';
+
+// This is what SHOULD happen (same as the truthy check in preg_match_checked.php):
+$expectedType = "array{0: non-falsy-string, 1: non-empty-string, 2: 'o', 3?: 'World'}";
+
+// BUG: $matches is NOT narrowed — actual type is array{}|array{...} instead of array{...}
+if (1 === preg_match($pattern, $string, $matches)) {
+    \PHPStan\Testing\assertSuperType($expectedType, $matches);
+}
+
+// BUG: same issue via FQCN
+if (1 === \Safe\preg_match($pattern, $string, $matches2)) {
+    \PHPStan\Testing\assertSuperType($expectedType, $matches2);
+}


### PR DESCRIPTION
 Syncs `PregMatchTypeSpecifyingExtension` and `PregMatchParameterOutTypeExtension` with upstream PHPStan changes introduced in phpstan/phpstan-src#5209, and adds a failing test that documents a remaining PHPStan core bug affecting all `preg_match` wrappers.
                                                                                                                                                                                                                   
## Changes                                

`PregMatchTypeSpecifyingExtension`: Replaced TrinaryLogic::createFromBoolean($context->true()) with proper three-way logic (createYes / createNo / createMaybe), matching the upstream implementation.                                               
   
 `PregMatchParameterOutTypeExtension`:  For `Safe\preg_match`, changed the out-type from createMaybe() (all offsets optional) to createYes() unioned with array{}. This fixes false "offset might not exist" errors when checking `$matches !== []` after a match — the exact issue addressed in phpstan/phpstan-src#5209.
                                                                                                                                                                                                                   
## Failing test: preg_match_identity_check.php

Please run 

```bash
php vendor/bin/phpunit
```

This test intentionally fails and documents a bug in PHPStan core that affects all extension-based `preg_match` wrappers (not just `Safe\preg_match`):                                                               

```php  
if (1 === Safe\preg_match($pattern, $string, $matches)) {                                                                                                                                                        
    $matches[1]; // PHPStan: Offset 1 might not exist on array{}|array{...}                                                                                                                                      
}                                                                                                                                                                                                                
```          
                                                                                                                                                                                                         
 Root cause: `TypeSpecifier::resolveNormalizedIdentical()` has a hardcoded literal-name check for 'preg_match'. It calls `specifyTypesInCondition()` on the `FuncCall`, but at that point the node is wrapped in `AlwaysRememberedExpr`. The `FunctionTypeSpecifyingExtension` dispatch only unwraps `AlwaysRememberedExpr` in `specifyTypesInCondition()` for the native `preg_match` — any other name (including `Safe\preg_match`) falls through without narrowing `$matches`.                                                                                                                                                                              
                                         
The plain truthy check if (`Safe\preg_match(...)`) works correctly. Only the identity check `1 ===` is broken.                                                                                                       
  
 This is a PHPStan core issue and cannot be fixed in this extension alone. The failing test serves as a reproducible bug report. A fix should be applied in `TypeSpecifier::resolveNormalizedIdentical()` to handle `AlwaysRememberedExpr-wrapped` calls from any registered `FunctionTypeSpecifyingExtension`, not just the hardcoded `preg_match` name.